### PR TITLE
Dart HTTP library modifies Content-Type

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -9,7 +9,7 @@ const _x_amz_security_token = 'x-amz-security-token';
 const _x_amz_content_sha256 = 'x-amz-content-sha256';
 const _host = 'Host';
 const _authorization = 'Authorization';
-const _default_content_type = 'application/json';
+const _default_content_type = 'application/json; charset=utf-8';
 const _default_accept_type = 'application/json';
 const _unsigned_payload = 'UNSIGNED-PAYLOAD';
 const _chunked_payload = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD';


### PR DESCRIPTION
The Dart HTTP library updates "application/json" to "application/json; charset=utf-8" which results in an invalid
signature for POST or PUT requests that did not specify a content-type.

This forces the correct Content-Type header by default.