### PR TITLE
Bump Null safety version number

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
     - name: Install dependencies
       run: pub get
     - name: Analyze
-      run: dart analyze
+      run: dart analyze lib
     - name: Run tests
-      run: dart test
+      run: dart run build_runner build && dart test
     - name: Setup credentials
       if: github.ref == 'refs/heads/master'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 .pub/
 build/
 sandbox/
+
+# generated classes
+client_test.mocks.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,3 +20,4 @@ dev_dependencies:
   mockito: ^5.0.2
   dotenv: ^3.0.0-nullsafety.0
   path: ^1.7.0
+  build_runner: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: sigv4
 description: Library for signing AWS requests with Signature Version 4, with both convenience wrappers/classes and cryptography methods
 homepage: https://github.com/arnemolland/sigv4
 
-version: 5.0.0-nullsafety.0
+version: 5.0.1-nullsafety.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,10 +1,13 @@
 import 'package:http/http.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:sigv4/sigv4.dart';
 
-class MockSigv4Client extends Mock implements Sigv4Client {}
+import 'client_test.mocks.dart';
 
+// For an explanation on this method of generating stubs, see https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md
+@GenerateMocks([Sigv4Client])
 void main() {
   group('#baseClient', () {
     late MockSigv4Client client;
@@ -35,7 +38,12 @@ void main() {
 
     test('throws on null/empty path', () {
       try {
-        client.signedHeaders('');
+        var client2 = Sigv4Client(
+            keyId: 'keyId',
+            accessKey: 'accessKey',
+            serviceName: 'serviceName',
+            region: 'region');
+        client2.signedHeaders('');
       } on AssertionError catch (e) {
         expect(e.runtimeType, AssertionError);
       }


### PR DESCRIPTION
This PR bumps the version number for the `null-safety` branch from `5.0.0-nullsafety.0` to `5.0.1-nullsafety.0` so the package will be recognized as an upgrade in the flutter pub archives.

I'm not sure why this PR includes commit from #31, but I didn't change anything else but the version number.